### PR TITLE
Updated Post Attachment Notification to Slack step

### DIFF
--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -142,7 +142,8 @@
         3.3 - Fixed issues with the JSON that was built
 	  </release-note>
     <release-note plugin-version="4">
-        4.0 - Changed the Post Custom Notification to Slack step name to Post Attachment Notification to Slack.
+        4.0 - Send Slack Attachment message to multiple channels.
+        4.1 - Changed the Post Custom Notification to Slack step name to Post Attachment Notification to Slack.
             - The Attachment Payload must now follow the exact JSON paylod for normal Attachment messages.
             - Various exception handling.
 	  </release-note>

--- a/plugin/info.xml
+++ b/plugin/info.xml
@@ -141,5 +141,10 @@
         3.2 - Removed Command Helper
         3.3 - Fixed issues with the JSON that was built
 	  </release-note>
+    <release-note plugin-version="4">
+        4.0 - Changed the Post Custom Notification to Slack step name to Post Attachment Notification to Slack.
+            - The Attachment Payload must now follow the exact JSON paylod for normal Attachment messages.
+            - Various exception handling.
+	  </release-note>
   </release-notes>
 </pluginInfo>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -8,7 +8,7 @@
 
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:server="http://www.urbancode.com/PluginServerXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier id="com.urbancode.air.plugin.slack" name="Slack" version="3"/>
+    <identifier id="com.urbancode.air.plugin.slack" name="Slack" version="4"/>
     <description>
        Plugin for sending notifications to Slack.
 	</description>
@@ -58,7 +58,7 @@
       <arg file="${PLUGIN_OUTPUT_PROPS}"/>
     </command>
   </step-type>
-  <step-type name="Post Custom Notification to Slack">
+  <step-type name="Post Attachment Notification to Slack">
     <description>
       Send a notification to a Slack channel.
 	</description>
@@ -76,7 +76,7 @@
         <property-ui default-value=":thumbsup:" description="The list of emoji supported are taken from https://github.com/iamcal/emoji-data ." label="Emoji Icon" type="textBox"/>
       </property>
       <property name="attachment" required="true">
-        <property-ui description="The payload value for adding to the attachment" label="Attachment Payload" type="textAreaBox"/>
+        <property-ui description="The Attachment JSON Payload to generate the Slack message." label="Attachment Payload" type="textAreaBox"/>
       </property>
     </properties>
     <post-processing><![CDATA[
@@ -90,7 +90,7 @@
     <command program="${GROOVY_HOME}/bin/groovy">
       <arg value="-cp"/>
       <arg path="classes:lib/commons-httpclient-3.1.jar:lib/gson-2.2.4.jar:lib/groovy-json-2.4.0.jar:lib/commons-codec-1.2.jar:lib/commons-logging-1.1.3.jar:lib/groovy-plugin-utils-1.2.jar"/>
-      <arg file="postToSlackCustom.groovy"/>
+      <arg file="postToSlackAttachment.groovy"/>
       <arg file="${PLUGIN_INPUT_PROPS}"/>
       <arg file="${PLUGIN_OUTPUT_PROPS}"/>
     </command>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -69,8 +69,8 @@
       <property name="username">
         <property-ui default-value="DevOps Bot" description="A custom name overriding the default defined in the webhook configuration" label="Username" type="textBox"/>
       </property>
-      <property name="channel" required="true">
-        <property-ui description="Your public channel within Slack where UrbanCode Deploy messages will be sent. The WebHook must have access to this channel." label="Channel" type="textBox"/>
+      <property name="channels" required="true">
+        <property-ui description="Your public channels or usernames within Slack where UrbanCode Deploy messages will be sent. The WebHook must have access to this channels. Separate each channel or username with a new line or comma." label="Channels" type="textAreaBox"/>
       </property>
       <property name="emoji" required="true">
         <property-ui default-value=":thumbsup:" description="The list of emoji supported are taken from https://github.com/iamcal/emoji-data ." label="Emoji Icon" type="textBox"/>

--- a/plugin/upgrade.xml
+++ b/plugin/upgrade.xml
@@ -10,6 +10,9 @@
   <!-- The purpose of plugin.xml is to provide upgrade paths when the plugin version is changed.
        If the upgrade paths are specified correctly, users will be upgraded to the new version
        without interruption. -->
-   <migrate to-version="3">
-   </migrate>
+    <migrate to-version="3">
+    </migrate>
+    <migrate to-version="4">
+        <migrate-command name="Post Attachment Notification to Slack" old="Post Custom Notification to Slack"/>
+    </migrate>
 </plugin-upgrade>

--- a/plugin/upgrade.xml
+++ b/plugin/upgrade.xml
@@ -13,6 +13,10 @@
     <migrate to-version="3">
     </migrate>
     <migrate to-version="4">
-        <migrate-command name="Post Attachment Notification to Slack" old="Post Custom Notification to Slack"/>
+        <migrate-command name="Post Attachment Notification to Slack" old="Post Custom Notification to Slack">
+            <migrate-properties>
+                <migrate-property name="channels" old="channel" default="" />
+            </migrate-properties>
+        </migrate-command>
     </migrate>
 </plugin-upgrade>


### PR DESCRIPTION
Resolves Issue #5 

Post Custom Notification to Slack step has been renamed to Post Attachment Notification to Slack and has been updated appropriately. 

Net fixes are general exception handling and the code looking for an atypical `content` map id. This id should instead be `attachments` to follow [Slack's API's payload standards](https://api.slack.com/docs/message-attachments#attachment-structure). 